### PR TITLE
Added Publisher ID Verification

### DIFF
--- a/src/components/GoogleAdSense.tsx
+++ b/src/components/GoogleAdSense.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import Script, { ScriptProps } from "next/script";
 
+const PUBLISHER_ID_REGEX = /^pub-\d{16}$/;
+
 type GoogleAdSenseProps = {
   publisherId: string;
   strategy?: ScriptProps["strategy"];
@@ -10,14 +12,20 @@ type GoogleAdSenseProps = {
 export function GoogleAdSense({
   publisherId,
   strategy = "afterInteractive",
-  debug = false
+  debug = false,
 }: GoogleAdSenseProps): JSX.Element | null {
   const _publisherId =
-      process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID ?? publisherId;
+    process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID ?? publisherId;
 
-  if(!_publisherId){
-    // TODO: check the format of publisherId here, some peeps new to adsense might enter a wrong id here.
-    console.error("nextjs-google-adsense: publisherId can't be empty for GoogleAdSense component");
+  if (!_publisherId) {
+    console.error(
+      "nextjs-google-adsense: publisherId can't be empty for GoogleAdSense component"
+    );
+    return null;
+  } else if (!PUBLISHER_ID_REGEX.test(_publisherId)) {
+    console.error(
+      "nextjs-google-adsense: publisherId is not in the correct format. It should be like this: pub-xxxxxxxxxxxxxxxx, there is a total of 16 digits behind pub-"
+    );
     return null;
   }
 
@@ -25,8 +33,11 @@ export function GoogleAdSense({
     <>
       <Script
         id="nextjs-google-adsense"
-        src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-${_publisherId}${debug ? `google_console=1`: ``}`}
-        strategy={strategy} />
+        src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-${_publisherId}${
+          debug ? `google_console=1` : ``
+        }`}
+        strategy={strategy}
+      />
     </>
   );
 }


### PR DESCRIPTION
Verify the input publisher ID. If the given ID does not start with "pub-" and ends with 16 digits, an error will pop up.

Regex Test Result
![image](https://github.com/btk/nextjs-google-adsense/assets/46896789/5245fba4-340c-43da-a514-64f90745ca95)
